### PR TITLE
Added CacheSizeSetter to ValorCurrentSensor

### DIFF
--- a/src/main/cpp/sensors/ValorCurrentSensor.cpp
+++ b/src/main/cpp/sensors/ValorCurrentSensor.cpp
@@ -19,18 +19,13 @@ void ValorCurrentSensor::setSpikeSetpoint(double _setpoint)
 
 void ValorCurrentSensor::setCacheSize(int _size)
 {
-    //maintain current average to avoid unwanted behavior
     if (_size < cacheSize) {
         for (int i = 0; i < cacheSize - _size; i++){
             cache.pop_front();
         }
     }
-    else {
-        for (int i = cacheSize; i < _size; i++) {
-            cache.push_front(prevState);
-        }
-    }
     cacheSize = _size;
+    reset();
 }
 
 void ValorCurrentSensor::setSpikeCallback(std::function<void()> _lambda)

--- a/src/main/cpp/sensors/ValorCurrentSensor.cpp
+++ b/src/main/cpp/sensors/ValorCurrentSensor.cpp
@@ -17,11 +17,18 @@ void ValorCurrentSensor::setSpikeSetpoint(double _setpoint)
     spikedSetpoint = _setpoint;
 }
 
-void ValorCurrentSensor::setCacheSize(double _size)
+void ValorCurrentSensor::setCacheSize(int _size)
 {
     //maintain current average to avoid unwanted behavior
-    for (int i = cacheSize; i < _size; i++) {
-        cache.push_back(prevState);
+    if (_size < cacheSize) {
+        for (int i = 0; i < cacheSize - _size; i++){
+            cache.pop_front();
+        }
+    }
+    else {
+        for (int i = cacheSize; i < _size; i++) {
+            cache.push_front(prevState);
+        }
     }
     cacheSize = _size;
 }

--- a/src/main/cpp/sensors/ValorCurrentSensor.cpp
+++ b/src/main/cpp/sensors/ValorCurrentSensor.cpp
@@ -17,6 +17,15 @@ void ValorCurrentSensor::setSpikeSetpoint(double _setpoint)
     spikedSetpoint = _setpoint;
 }
 
+void ValorCurrentSensor::setCacheSize(double _size)
+{
+    //maintain current average to avoid unwanted behavior
+    for (int i = cacheSize; i < _size; i++) {
+        cache.push_back(prevState);
+    }
+    cacheSize = _size;
+}
+
 void ValorCurrentSensor::setSpikeCallback(std::function<void()> _lambda)
 {
     spikeCallback = _lambda;

--- a/src/main/cpp/sensors/ValorCurrentSensor.cpp
+++ b/src/main/cpp/sensors/ValorCurrentSensor.cpp
@@ -19,11 +19,6 @@ void ValorCurrentSensor::setSpikeSetpoint(double _setpoint)
 
 void ValorCurrentSensor::setCacheSize(int _size)
 {
-    if (_size < cacheSize) {
-        for (int i = 0; i < cacheSize - _size; i++){
-            cache.pop_front();
-        }
-    }
     cacheSize = _size;
     reset();
 }

--- a/src/main/include/sensors/ValorCurrentSensor.h
+++ b/src/main/include/sensors/ValorCurrentSensor.h
@@ -61,7 +61,7 @@ public:
      * 
      * @param size The size of the cache that stores current values
      */
-    void setCacheSize(double _size);
+    void setCacheSize(int _size);
 
     void InitSendable(wpi::SendableBuilder& builder) override;
 
@@ -73,5 +73,5 @@ private:
     std::deque<double> cache;
 
     double spikedSetpoint;
-    double cacheSize;
+    int cacheSize;
 };

--- a/src/main/include/sensors/ValorCurrentSensor.h
+++ b/src/main/include/sensors/ValorCurrentSensor.h
@@ -54,7 +54,14 @@ public:
      * 
      * @param threshold The average current value that will trigger the spiked function
      */
-    void setSpikeSetpoint(double threshold);
+    void setSpikeSetpoint(double _setpoint);
+
+     /**
+     * @brief Set the cache size to be averaged for determining spiked value
+     * 
+     * @param size The size of the cache that stores current values
+     */
+    void setCacheSize(double _size);
 
     void InitSendable(wpi::SendableBuilder& builder) override;
 


### PR DESCRIPTION
CacheSizeSetter Added to ValorCurrentSensor. Fills deficit number of spots with average value to maintain current average to prevent unwanted behavior is switching cache size while running.