### PR TITLE
Cjn elevarm checklist

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -12,7 +12,7 @@
 
 #include <ctime>
 
-Robot::Robot() : drivetrain(this), intake(this), elevarm(this), autonomous(&drivetrain, &intake, &elevarm)
+Robot::Robot() : drivetrain(this), intake(this), elevarm(this, &intake), autonomous(&drivetrain, &intake, &elevarm)
 {
     frc::TimedRobot();
 }

--- a/src/main/cpp/subsystems/Elevarm.cpp
+++ b/src/main/cpp/subsystems/Elevarm.cpp
@@ -328,13 +328,13 @@ Elevarm::Positions Elevarm::detectionBoxManual(double carriage, double arm) {
 }
 
 
-Elevarm::Positions Elevarm::reverseKinematics(frc::Pose3d pose, ElevarmSolutions solution, ElevarmDirectionState direction) 
+Elevarm::Positions Elevarm::reverseKinematics(frc::Pose3d pose, ElevarmSolutions solution, ElevarmDirectionState dir) 
 {
     double phi = 0.0;
     double theta = 0.0;
     double height = 0.0;
 
-    double direction = (direction == ElevarmDirectionState::ELEVARM_FRONT) ? 1.0 : -1.0;
+    double direction = (dir == ElevarmDirectionState::ELEVARM_FRONT) ? 1.0 : -1.0;
 
     // Arms solution
     if (solution == ElevarmSolutions::ELEVARM_ARMS) {

--- a/src/main/cpp/subsystems/Intake.cpp
+++ b/src/main/cpp/subsystems/Intake.cpp
@@ -40,30 +40,34 @@ void Intake::init()
 
 void Intake::assessInputs()
 {
-    if (driverGamepad->GetAButton()) {
-        // works with elevarm locations in order to outtake at speed for cone/cube
-        if (operatorGamepad->DPadDown() || operatorGamepad->DPadUp()
-            || operatorGamepad->DPadLeft() || operatorGamepad->DPadRight()) {
-            state.intakeState = OUTTAKE_CUBE;
-        } else if (operatorGamepad->GetAButton() || operatorGamepad->GetBButton() 
-                || operatorGamepad->GetXButton() || operatorGamepad->GetYButton()) {
-            state.intakeState = OUTTAKE_CONE;
-        } else {
-            state.intakeState = OUTTAKE;
-        }
-    } else if (operatorGamepad->rightTriggerActive()) {
-        state.intakeState = OUTTAKE;
-    } else if (state.intakeState != SPIKED) {
-        if (driverGamepad->GetLeftBumper() || driverGamepad->GetRightBumper() || operatorGamepad->leftTriggerActive()) {
-            state.intakeState = INTAKE;
-        } else{
-            state.intakeState = DISABLED;
-        }
-    } else if(state.intakeState == SPIKED) {
-        if (!driverGamepad->GetLeftBumper() && !driverGamepad->GetRightBumper() && !operatorGamepad->leftTriggerActive()) {
-            state.intakeState = DISABLED;
-        } 
-    }
+    // if (driverGamepad->GetAButton()) {
+    //     // works with elevarm locations in order to outtake at speed for cone/cube
+    //     if (operatorGamepad->DPadDown() || operatorGamepad->DPadUp()
+    //         || operatorGamepad->DPadLeft() || operatorGamepad->DPadRight()) {
+    //         state.intakeState = OUTTAKE_CUBE;
+    //     } else if (operatorGamepad->GetAButton() || operatorGamepad->GetBButton() 
+    //             || operatorGamepad->GetXButton() || operatorGamepad->GetYButton()) {
+    //         state.intakeState = OUTTAKE_CONE;
+    //     } else {
+    //         state.intakeState = OUTTAKE;
+    //     }
+    // } else if (operatorGamepad->rightTriggerActive()) {
+    //     state.intakeState = OUTTAKE;
+    // } else if (state.intakeState != SPIKED) {
+    //     if (driverGamepad->GetLeftBumper() || driverGamepad->GetRightBumper() || operatorGamepad->leftTriggerActive() ||
+    //      operatorGamepad->GetXButton()  || operatorGamepad->DPadLeft() || operatorGamepad->GetAButton() ||
+    //       operatorGamepad->DPadDown()) {
+    //         state.intakeState = INTAKE;
+    //     } else{
+    //         state.intakeState = DISABLED;
+    //     }
+    // } else if(state.intakeState == SPIKED) {
+    //     if (!driverGamepad->GetLeftBumper() && !driverGamepad->GetRightBumper() && !operatorGamepad->leftTriggerActive()) {
+    //         state.intakeState = DISABLED;
+    //     } 
+    // }
+    if (driverGamepad->leftTriggerActive()) state.intakeState = SPIKED;
+    else state.intakeState = DISABLED;
 }
 
 void Intake::analyzeDashboard()
@@ -72,6 +76,7 @@ void Intake::analyzeDashboard()
     outtakeSpeed = table->GetNumber("Outtake Speed", 0);
     outtakeConeSpeed = table->GetNumber("Outtake Cone Speed", 0);
     outtakeCubeSpeed = table->GetNumber("Outtake Cube Speed", 0);
+
 }
  
 void Intake::assignOutputs()

--- a/src/main/include/subsystems/Elevarm.h
+++ b/src/main/include/subsystems/Elevarm.h
@@ -11,6 +11,7 @@
 #include "Constants.h"
 #include "controllers/ValorFalconController.h"
 #include "controllers/ValorNeoController.h"
+#include "subsystems/Intake.h"
 
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc/smartdashboard/SmartDashboard.h>
@@ -30,7 +31,7 @@ public:
       * 
       * @param robot Top level robot object to parse out smart dashboard and table information
       */
-     Elevarm(frc::TimedRobot *robot);
+     Elevarm(frc::TimedRobot *robot , Intake *_intake);
 
      /**
       * @brief Destroy the Elevarm object
@@ -83,7 +84,8 @@ public:
         ELEVARM_PLAYER,
         ELEVARM_MID,
         ELEVARM_HIGH,
-        ELEVARM_MANUAL
+        ELEVARM_MANUAL,
+        ELEVARM_SNAKE
     };
 
     enum ElevarmSolutions {
@@ -130,9 +132,11 @@ private:
      std::map<ElevarmPieceState, std::map<ElevarmDirectionState, std::map<ElevarmPositionState, frc::Pose3d>>> posMap;
      frc::Pose3d stowPos;
 
-    Positions reverseKinematics(frc::Pose3d pose, ElevarmSolutions); 
+    Positions reverseKinematics(frc::Pose3d pose, ElevarmSolutions, ElevarmDirectionState); 
     frc::Pose3d forwardKinematics(Positions positions);
     Positions detectionBoxManual(double, double);
+
+    Intake *intake;
      
      double manualMaxCarriageSpeed;
      double manualMaxArmSpeed;


### PR DESCRIPTION
Added intermediate point logic with snake position and stow position that uses input from intake states and sets intake states. 
Intake AssessInputs is commented out to force testing with currentSensor SPIKED logic.
Safety logic with chassis works with snake intermediate position.
Resolved ReverseKinematics bug with intake Z offset and PHI angle calculation