### PR TITLE
fix: State changes in auto

### DIFF
--- a/src/main/include/subsystems/Elevarm.h
+++ b/src/main/include/subsystems/Elevarm.h
@@ -102,7 +102,7 @@ public:
         double manualCarriage;
         double manualArm;
 
-
+        bool stowFirst;
 
         Positions targetPose;
         frc::Pose3d resultKinematics;
@@ -135,6 +135,9 @@ private:
     Positions reverseKinematics(frc::Pose3d pose, ElevarmSolutions, ElevarmDirectionState); 
     frc::Pose3d forwardKinematics(Positions positions);
     Positions detectionBoxManual(double, double);
+
+    bool carriageAtTarget();
+    bool armAtTarget();
 
     Intake *intake;
      


### PR DESCRIPTION
Writing over futureState in assignOutputs could have un-intended consequences when working with auto. Instead, never touch futureState except for auto and assessInputs in teleop