### PR TITLE
Fix(auto)(1 piece autos): roll through stow point

### DIFF
--- a/scripts/auto/autos/barrier1_left.csv
+++ b/scripts/auto/autos/barrier1_left.csv
@@ -5,7 +5,9 @@ intake,outtake_cone
 time,1000
 intake,disabled
 trajectory,barrierLeft,barrierStartLeft,180,reversed
+split,0.25,multiplier
 elevarm,cone,front,stow,parallel
+split,0.25,multiplier
 trajectory,barrierStartLeft,chell,180,reversed
 trajectory,chell,chellFar,180,reversed
 split,0.25,multiplier

--- a/scripts/auto/autos/barrier1_left.csv
+++ b/scripts/auto/autos/barrier1_left.csv
@@ -1,6 +1,5 @@
-reset_odom,barrierStartLeft,180
+reset_odom,barrierLeft,180
 elevarm,cone,front,high
-trajectory,barrierStartLeft,barrierLeft,180
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/barrier1_right.csv
+++ b/scripts/auto/autos/barrier1_right.csv
@@ -5,7 +5,9 @@ intake,outtake_cone
 time,1000
 intake,disabled
 trajectory,barrierRight,barrierStartRight,180,reversed
+split,0.25,multiplier
 elevarm,cone,front,stow,parallel
+split,0.25,multiplier
 trajectory,barrierStartRight,chell,180,reversed
 trajectory,chell,chellFar,180,reversed
 split,0.25,multiplier

--- a/scripts/auto/autos/barrier1_right.csv
+++ b/scripts/auto/autos/barrier1_right.csv
@@ -1,6 +1,5 @@
-reset_odom,barrierStartRight,180
+reset_odom,barrierRight,180
 elevarm,cone,front,high
-trajectory,barrierStartRight,barrierRight,180
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/wall1_left.csv
+++ b/scripts/auto/autos/wall1_left.csv
@@ -1,6 +1,5 @@
-reset_odom,wallStartLeft,180
+reset_odom,wallLeft,180
 elevarm,cone,front,high
-trajectory,wallStartLeft,wallLeft,180
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/wall1_left.csv
+++ b/scripts/auto/autos/wall1_left.csv
@@ -5,7 +5,9 @@ intake,outtake_cone
 time,1000
 intake,disabled
 trajectory,wallLeft,wallStartLeft,180,reversed
+split,0.25,multiplier
 elevarm,cone,front,stow,parallel
+split,0.25,multiplier
 trajectory,wallStartLeft,glados,180,reversed
 trajectory,glados,gladosFar,180,reversed
 split,0.25,multiplier

--- a/scripts/auto/autos/wall1_right.csv
+++ b/scripts/auto/autos/wall1_right.csv
@@ -5,7 +5,9 @@ intake,outtake_cone
 time,1000
 intake,disabled
 trajectory,wallRight,wallStartRight,180,reversed
+split,0.25,multiplier
 elevarm,cone,front,stow,parallel
+split,0.25,multiplier
 trajectory,wallStartRight,glados,180,reversed
 trajectory,glados,gladosFar,180,reversed
 split,0.25,multiplier

--- a/scripts/auto/autos/wall1_right.csv
+++ b/scripts/auto/autos/wall1_right.csv
@@ -1,6 +1,5 @@
-reset_odom,wallStartRight,180
+reset_odom,wallRight,180
 elevarm,cone,front,high
-trajectory,wallStartRight,wallRight,180
 time,1000
 intake,outtake_cone
 time,1000


### PR DESCRIPTION
currently, in the 1 piece autos, after scoring thee robot moves to a position, stops, then begins a parallel sequence to lower the arm to stow. Instead robot should roll through this position and trajectories should be merged so that there is one continuous motion and no stop at the rotate point.