### PR TITLE
fix(auto): Set arm rotate PID in auto to slower accel

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -82,6 +82,7 @@ void Robot::AutonomousPeriodic(){
 void Robot::TeleopInit() {
     drivetrain.pullSwerveModuleZeroReference();
     drivetrain.setDriveMotorNeutralMode(ValorNeutralMode::Coast);
+    elevarm.setArmPIDF(false);
 
     if (autoCommand != nullptr) {
         autoCommand->Cancel();

--- a/src/main/cpp/auto/ValorAuto.cpp
+++ b/src/main/cpp/auto/ValorAuto.cpp
@@ -144,6 +144,8 @@ frc2::SequentialCommandGroup* ValorAuto::makeAuto(std::string filename, bool blu
     int trajCount = 0;
 
     drivetrain->setAutoMaxAcceleration(NULL, 1.0);
+    
+    currentGroup->AddCommands(std::move(*elevarm->getRotatePIDSetterCommand(true)));
 
     for (int i = 0; i < actions.size(); i ++){
         table->PutString("Action " + std::to_string(i), commandToStringMap[actions[i].type]);
@@ -412,7 +414,7 @@ frc2::SequentialCommandGroup* ValorAuto::makeAuto(std::string filename, bool blu
     cmdGroups.push_back(std::move(*currentGroup));
 
     // bad way of doing this currently this relies on 
-    // adding the action command group and the other command group in a specific order, which i know i'll fuck up some day
+    // adding the action command group and the other command group in a specific order, which i know i'll mess up some day
     // the action command group and other cocmmadn group should be named
     frc2::SequentialCommandGroup * combinedGroup = new frc2::SequentialCommandGroup(std::move(cmdGroups[0]));
     for (int i = cmdGroups.size() - 1; i >= 1; i -= 2){
@@ -422,6 +424,8 @@ frc2::SequentialCommandGroup* ValorAuto::makeAuto(std::string filename, bool blu
             )
         );
     }
+
+    combinedGroup->AddCommands(std::move(*elevarm->getRotatePIDSetterCommand(false)));
 
     return combinedGroup;
 }

--- a/src/main/include/subsystems/Elevarm.h
+++ b/src/main/include/subsystems/Elevarm.h
@@ -125,6 +125,8 @@ public:
 
     frc2::FunctionalCommand * getAutoCommand(std::string, std::string, std::string, bool);
 
+    frc2::FunctionalCommand * getRotatePIDSetterCommand(bool);
+
     std::unordered_map<std::string, ElevarmPieceState> stringToPieceMap = {
         {"cone", ElevarmPieceState::ELEVARM_CONE},
         {"cube", ElevarmPieceState::ELEVARM_CUBE}
@@ -155,6 +157,8 @@ public:
             return ElevarmPositionState::ELEVARM_GROUND;
         return stringToPositionMap.at(name);
     }
+
+    void setArmPIDF(bool);
 
 private:
 
@@ -187,6 +191,11 @@ private:
     Positions detectionBoxManual(double, double);
 
     Intake *intake;
+
+    ValorPIDF carriagePID;
+    ValorPIDF rotatePID;
+    ValorPIDF autoRotatePID;
+    ValorPIDF wristPID;
      
      double manualMaxCarriageSpeed;
      double manualMaxArmSpeed;


### PR DESCRIPTION
slow down accel of arm in auto to prevent the behavior of the arm swinging like crazy at the start of auto and tipping the robot.
Tested ✅ 