### PR TITLE
fix: high auto postion on wrist will rotate oposite direction

### DIFF
--- a/scripts/auto/autos/barrier1_left_climb.csv
+++ b/scripts/auto/autos/barrier1_left_climb.csv
@@ -1,5 +1,5 @@
 reset_odom,barrierLeft,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/barrier1_right_climb.csv
+++ b/scripts/auto/autos/barrier1_right_climb.csv
@@ -1,5 +1,5 @@
 reset_odom,barrierRight,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/barrier2_left_with_cube.csv
+++ b/scripts/auto/autos/barrier2_left_with_cube.csv
@@ -1,5 +1,5 @@
 reset_odom,barrierLeft,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/barrier2_right_with_cube.csv
+++ b/scripts/auto/autos/barrier2_right_with_cube.csv
@@ -1,5 +1,5 @@
 reset_odom,barrierRight,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/coop1_left_climb.csv
+++ b/scripts/auto/autos/coop1_left_climb.csv
@@ -1,5 +1,5 @@
 reset_odom,coopLeft,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/coop1_right_climb.csv
+++ b/scripts/auto/autos/coop1_right_climb.csv
@@ -1,5 +1,5 @@
 reset_odom,coopRight,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/noMove_coop1_left.csv
+++ b/scripts/auto/autos/noMove_coop1_left.csv
@@ -1,5 +1,5 @@
 reset_odom,coopLeft,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/noMove_coop1_right.csv
+++ b/scripts/auto/autos/noMove_coop1_right.csv
@@ -1,5 +1,5 @@
 reset_odom,coopRight,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/wall1_left_climb.csv
+++ b/scripts/auto/autos/wall1_left_climb.csv
@@ -1,5 +1,5 @@
 reset_odom,wallLeft,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/wall1_right_climb.csv
+++ b/scripts/auto/autos/wall1_right_climb.csv
@@ -1,5 +1,5 @@
 reset_odom,wallRight,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/wall2_left_with_cube.csv
+++ b/scripts/auto/autos/wall2_left_with_cube.csv
@@ -1,5 +1,5 @@
 reset_odom,wallLeft,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/scripts/auto/autos/wall2_right_with_cube.csv
+++ b/scripts/auto/autos/wall2_right_with_cube.csv
@@ -1,5 +1,5 @@
 reset_odom,wallRight,180
-elevarm,cone,front,high
+elevarm,cone,front,high_auto
 time,1000
 intake,outtake_cone
 time,1000

--- a/src/main/cpp/subsystems/Elevarm.cpp
+++ b/src/main/cpp/subsystems/Elevarm.cpp
@@ -187,6 +187,7 @@ void Elevarm::init()
     posMap[ElevarmPieceState::ELEVARM_CONE][ElevarmDirectionState::ELEVARM_FRONT][ElevarmPositionState::ELEVARM_PLAYER] =frc::Pose2d(-0.033_m, 1.423_m, 303.3_deg);
     posMap[ElevarmPieceState::ELEVARM_CONE][ElevarmDirectionState::ELEVARM_FRONT][ElevarmPositionState::ELEVARM_MID] =frc::Pose2d(0.286_m, 1.295_m, 269.5_deg);
     posMap[ElevarmPieceState::ELEVARM_CONE][ElevarmDirectionState::ELEVARM_FRONT][ElevarmPositionState::ELEVARM_HIGH] =frc::Pose2d(0.516_m, 1.49_m, 220.0_deg);
+    posMap[ElevarmPieceState::ELEVARM_CONE][ElevarmDirectionState::ELEVARM_FRONT][ElevarmPositionState::ELEVARM_HIGH_AUTO] =frc::Pose2d(0.516_m, 1.49_m, -140.0_deg);
     posMap[ElevarmPieceState::ELEVARM_CONE][ElevarmDirectionState::ELEVARM_FRONT][ElevarmPositionState::ELEVARM_SNAKE] =frc::Pose2d(0.086_m, 1.16_m, 253.2_deg);
     // FRONT CUBE
     posMap[ElevarmPieceState::ELEVARM_CUBE][ElevarmDirectionState::ELEVARM_FRONT][ElevarmPositionState::ELEVARM_GROUND] =frc::Pose2d(0.13_m, 0.28_m, 173.85_deg);

--- a/src/main/include/subsystems/Elevarm.h
+++ b/src/main/include/subsystems/Elevarm.h
@@ -93,6 +93,7 @@ public:
         ELEVARM_PLAYER,
         ELEVARM_MID,
         ELEVARM_HIGH,
+        ELEVARM_HIGH_AUTO,
         ELEVARM_MANUAL,
         ELEVARM_SNAKE
     };
@@ -152,6 +153,7 @@ public:
         {"player", ElevarmPositionState::ELEVARM_PLAYER},
         {"mid", ElevarmPositionState::ELEVARM_MID},
         {"high", ElevarmPositionState::ELEVARM_HIGH},
+        {"high_auto", ElevarmPositionState::ELEVARM_HIGH_AUTO},
         {"manual", ElevarmPositionState::ELEVARM_MANUAL},
         {"ground_score", ElevarmPositionState::ELEVARM_GROUND_SCORE},
         {"snake", ElevarmPositionState::ELEVARM_SNAKE}


### PR DESCRIPTION
Problem: wrist in auto rotates over the top and causes large acceleration

solution: high setpoint at start of auto is -360 offset from regular high

closes #91 