### PR TITLE
feat: LEDs for elevarm and intake state

### DIFF
--- a/src/main/cpp/sensors/ValorCANdleSensor.cpp
+++ b/src/main/cpp/sensors/ValorCANdleSensor.cpp
@@ -29,7 +29,7 @@ ValorCANdleSensor::ValorCANdleSensor(frc::TimedRobot *_robot, int _ledCount, int
     ctre::phoenix::led::CANdleConfiguration config;
     // Should match the type of LED strip connected to the CANdle
     config.stripType = ctre::phoenix::led::LEDStripType::GRB;
-    config.brightnessScalar = 0.75;
+    config.brightnessScalar = 1.0;
     config.statusLedOffWhenActive = true;
     config.disableWhenLOS = false;
     // If the 12V line should be on, off, or modulated (for single LED colors)
@@ -41,9 +41,9 @@ ValorCANdleSensor::ValorCANdleSensor(frc::TimedRobot *_robot, int _ledCount, int
 ValorCANdleSensor::RGBColor ValorCANdleSensor::toRGB(int color)
 {
     RGBColor outColor;
-    outColor.red = ((color & 0xFF0000) >> 16) * 255;
-    outColor.green = ((color & 0x00FF00) >> 8) * 255;
-    outColor.blue = ((color & 0x0000FF)) * 255;
+    outColor.red = ((color & 0xFF0000) >> 16);
+    outColor.green = ((color & 0x00FF00) >> 8);
+    outColor.blue = ((color & 0x0000FF));
     return outColor;
 }
 
@@ -54,14 +54,13 @@ ValorCANdleSensor::~ValorCANdleSensor()
 
 void ValorCANdleSensor::setColor(int r, int g, int b)
 {
-    candle.SetLEDs(r,g,b);
+    candle.SetLEDs(r,g,b,0,0,8 + ledCount);
 }
 
 void ValorCANdleSensor::setColor(int color)
 {
-    clearAnimation();
     currentColor = toRGB(color);
-    candle.SetLEDs(currentColor.red, currentColor.green, currentColor.blue,0,0,ledCount);
+    candle.SetLEDs(currentColor.red, currentColor.green, currentColor.blue,0,0,8 + ledCount);
 }
 
 void ValorCANdleSensor::setAnimation(ValorCANdleSensor::AnimationType animation)

--- a/src/main/include/Constants.h
+++ b/src/main/include/Constants.h
@@ -55,4 +55,5 @@ namespace CANIDs {
     constexpr static int ARM_ROTATE = 11;
     constexpr static int ARM_CANCODER = 14;
     constexpr static int WRIST = 15;
+    constexpr static int CANDLE = 60;
 }

--- a/src/main/include/subsystems/Elevarm.h
+++ b/src/main/include/subsystems/Elevarm.h
@@ -16,6 +16,7 @@
 #include "subsystems/Direction.h"
 #include "subsystems/Position.h"
 #include "subsystems/Piece.h"
+#include "sensors/ValorCANdleSensor.h"
 
 #include <frc/smartdashboard/SendableChooser.h>
 #include <frc/smartdashboard/SmartDashboard.h>
@@ -104,6 +105,10 @@ public:
 
         double carraigeOffset;
 
+        bool atCarriage;
+        bool atArm;
+        bool atWrist;
+
     } futureState, previousState;
 
     double heightDeadband, rotationDeadband;
@@ -178,6 +183,7 @@ private:
     Positions detectionBoxManual(double, double);
 
     Intake *intake;
+    ValorCANdleSensor candle;
 
     ValorPIDF carriagePID;
     ValorPIDF rotatePID;


### PR DESCRIPTION
# LEDs

Use the CANdle to represent state of the robot via LEDs. Future code includes enabling the LED bar

## Auto 

* Green - Arm, Wrist, and Elevator at desired position and within deadband
* Blue - Any component (arm, wrist, or elevator) have not arrived at the setpoint

## Teleop

* Red - Spiked flag is set, robot believes it has a game piece
* Yellow - Driver or operator intending to manipulate a cone
* Purple - Driver or operator intending to manipulate a cube