### PR TITLE
Brake switch

### DIFF
--- a/src/main/cpp/controllers/ValorFalconController.cpp
+++ b/src/main/cpp/controllers/ValorFalconController.cpp
@@ -150,6 +150,7 @@ void ValorFalconController::setNeutralMode(ValorNeutralMode mode){
     neutralMode = mode;
 }
 
+
 void ValorFalconController::InitSendable(wpi::SendableBuilder& builder)
 {
     builder.SetSmartDashboardType("Subsystem");

--- a/src/main/include/controllers/ValorController.h
+++ b/src/main/include/controllers/ValorController.h
@@ -280,6 +280,10 @@ public:
 
     virtual void setNeutralMode(ValorNeutralMode mode) = 0;
 
+    ValorNeutralMode getNeutralMode(){
+        return neutralMode;
+    }
+
     virtual void InitSendable(wpi::SendableBuilder& builder) = 0;
 
     virtual double getAbsEncoderPosition() = 0;

--- a/src/main/include/subsystems/Elevarm.h
+++ b/src/main/include/subsystems/Elevarm.h
@@ -116,6 +116,7 @@ public:
     double heightDeadband, rotationDeadband;
     
     bool zeroArm;
+    bool coastMode;
 
     frc2::FunctionalCommand * getAutoCommand(std::string, std::string, std::string);
 


### PR DESCRIPTION
Added a getNeutralMode() function to both Valor Falcon/Neo Controllers
Added a boolean called coastMode, used to switch between coast and brake mode using a dashboard button