### PR TITLE
Carriage bounding logic for High scoring

### DIFF
--- a/src/main/cpp/subsystems/Elevarm.cpp
+++ b/src/main/cpp/subsystems/Elevarm.cpp
@@ -426,13 +426,15 @@ void Elevarm::assignOutputs()
                 (futureState.directionState == Direction::BACK && armRotateMotor.getPosition() < -26.0) ||
                  (armRotateMotor.getPosition() > 100.0) ||
                  (armRotateMotor.getPosition() < -90.0)) {
-                // wristMotor.setPosition(futureState.targetPose.wrist);
-                armRotateMotor.setPosition(futureState.targetPose.theta);
-                carriageMotors.setPosition(futureState.targetPose.h);
 
-                if (futureState.atCarriage) {
+                armRotateMotor.setPosition(futureState.targetPose.theta);
+                
+                if ((futureState.positionState == Position::HIGH && armRotateMotor.getPosition() > -200.0) 
+                || futureState.atCarriage) {
                     carriageMotors.setPower(carriageStallPower);
-                }
+                } else 
+                    carriageMotors.setPosition(futureState.targetPose.h);
+                
             } else {
                 if (intake->getFuturePiece() == Piece::CUBE && futureState.positionState == Position::STOW && previousState.positionState == Position::STOW && futureState.atCarriage) {
                     carriageMotors.setPower(carriageStallPower);
@@ -452,7 +454,7 @@ void Elevarm::assignOutputs()
             } else {
                 wristMotor.setPosition(stowPos.Rotation().Degrees().to<double>());
             }
-    
+
             if (futureState.atCarriage && futureState.atArm && futureState.atWrist) {
                 previousState = futureState;
                 setPrevPiece(intake->getFuturePiece());

--- a/src/main/cpp/subsystems/Elevarm.cpp
+++ b/src/main/cpp/subsystems/Elevarm.cpp
@@ -7,7 +7,7 @@
 #include "subsystems/Elevarm.h"
 #include <iostream>
 
-#define IS_COMP
+// #define IS_COMP
 
 #ifdef IS_COMP
 #define ROTATE_GEAR_RATIO 83.53f
@@ -16,11 +16,11 @@
 #define ARM_CANCODER_OFFSET  323.61f
 #define WRIST_CANCODER_OFFSET 57.83f
 #else
-#define ROTATE_GEAR_RATIO 74.25f
-#define WRIST_GEAR_RATIO 15.43f
+#define ROTATE_GEAR_RATIO 83.53f
+#define WRIST_GEAR_RATIO 24.3f
 
-#define ARM_CANCODER_OFFSET  303.925f
-#define WRIST_CANCODER_OFFSET 50.8f
+#define ARM_CANCODER_OFFSET  300.925f
+#define WRIST_CANCODER_OFFSET 122.81f
 #endif
 
 #define CARRIAGE_GEAR_RATIO 4.0f
@@ -261,7 +261,7 @@ void Elevarm::init()
     table->PutBoolean("Coast Mode", coastMode);
 
     resetState();
-    armRotateMotor.setEncoderPosition((armCANcoder.GetAbsolutePosition() - ARM_CANCODER_OFFSET) / ARM_CANCODER_GEAR_RATIO + 180.0);
+    armRotateMotor.setEncoderPosition((armCANcoder.GetAbsolutePosition() - ARM_CANCODER_OFFSET) / ARM_CANCODER_GEAR_RATIO - 180.0);
     carriageMotors.setEncoderPosition(0.0);
     wristMotor.setEncoderPosition((wristCANcoder.GetAbsolutePosition() - WRIST_CANCODER_OFFSET) / WRIST_CANCODER_GEAR_RATIO);
     wristCANcoder.SetStatusFramePeriod(CANCoderStatusFrame_SensorData, 50, 1000); // changes the period of the sensor data frame to 50ms

--- a/src/main/cpp/subsystems/ValorSwerve.cpp
+++ b/src/main/cpp/subsystems/ValorSwerve.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <string>
 
-#define IS_COMP
+// #define IS_COMP
 
 #ifdef IS_COMP
 #define WHEEL_0_INIT 0.3106f


### PR DESCRIPTION
Prevents carriage from moving until after the arm reaches a certain negative position while going to high-scoring positions.