### PR TITLE
Feat: Setpoint Jogger

### DIFF
--- a/src/main/include/subsystems/Elevarm.h
+++ b/src/main/include/subsystems/Elevarm.h
@@ -105,7 +105,7 @@ public:
         double frontMinAngle;
         double backMinAngle;
 
-        double carraigeOffset;
+        double carriageOffset;
 
         bool atCarriage;
         bool atArm;


### PR DESCRIPTION
added a carriage jogger, removed network table usage from carriage offset and replaced it w operator and driver gamepad, took out poopfull so that operator A button was free for carriage offset